### PR TITLE
Suggested fix for: ReferenceError: docpad not defined

### DIFF
--- a/src/navlinks.plugin.coffee
+++ b/src/navlinks.plugin.coffee
@@ -15,7 +15,7 @@ module.exports = (BasePlugin) ->
       for collectionName, sorting of config.collections
         collection = @docpad.getCollection(collectionName)
         if collection?
-          docpad.log 'info', 'Adding navlinks for collection: ', collectionName
+          @docpad.log 'info', 'Adding navlinks for collection: ', collectionName
           index = 0
           collection.forEach (document) ->
             navlinks = navlinks:


### PR DESCRIPTION
This should potentially fix #4. Or more specifically in the generated js file if I add a `this.` in front of the reference to `docpad` on line 30 then it works. From that I assume that adding an `@` in the coffee script at line 18 should fix the problem.
